### PR TITLE
remove logger message

### DIFF
--- a/src/main/java/btdex/core/Globals.java
+++ b/src/main/java/btdex/core/Globals.java
@@ -97,7 +97,6 @@ public class Globals {
 			loadAccounts();
 		}
 		catch (Exception e) {
-			logger.error("Error: {}", e.getLocalizedMessage());
 			e.printStackTrace();
 		}
 	}


### PR DESCRIPTION
I guess that exception can be trowed earlier then logger initialized, so it can break code.