### PR TITLE
Wrong variable was called

### DIFF
--- a/src/main/java/btdex/ui/MiningPanel.java
+++ b/src/main/java/btdex/ui/MiningPanel.java
@@ -1370,7 +1370,7 @@ public class MiningPanel extends JPanel implements ActionListener, ChangeListene
 		} catch (IOException ex) {
 			ex.printStackTrace();
 			Toast.makeText((JFrame) SwingUtilities.getWindowAncestor(this), ex.getMessage(), Toast.Style.ERROR).display();
-			plotting = false;
+			mining = false;
 			return;
 		}
 		MineThread mineThread = new MineThread();


### PR DESCRIPTION
When this exception happens, the intention is to change the boolean that indicates mining as "in progress". However, the variable called here is the one for plotting. Fixed.