### PR TITLE
Adding support to handle "Use Direct IO" 

### DIFF
--- a/src/main/java/btdex/ui/MiningPanel.java
+++ b/src/main/java/btdex/ui/MiningPanel.java
@@ -93,6 +93,7 @@ public class MiningPanel extends JPanel implements ActionListener, ChangeListene
 	private static final String PROP_MINE_ONLY_BEST = "mineOnlyBest";
 	private static final String PROP_MINER_POOL = "minerPool";
 	private static final String PROP_MINER_AUTO_START = "minerAutoStart";
+        private static final String PROP_MINER_USE_DIRECT_IO = "minerUseDirectIO";
 	
 	private static final String PLOT_APP = "[PLOTTER]";
 	private static final String MINER_APP = "[MINER]";
@@ -161,8 +162,10 @@ public class MiningPanel extends JPanel implements ActionListener, ChangeListene
 	private JComboBox<String> cpusToMineComboBox;
 
 	private JComboBox<String> poolComboBox;
-	
+
 	private JCheckBox mineSubmitOnlyBest;
+
+	private JCheckBox mineUseDirectIO;
 
 	private JButton joinPoolButton, openPoolButton;
 
@@ -383,7 +386,12 @@ public class MiningPanel extends JPanel implements ActionListener, ChangeListene
 		mineSubmitOnlyBest.setSelected(!"false".equals(g.getProperty(PROP_MINE_ONLY_BEST)));
 		mineSubmitOnlyBest.addActionListener(this);
 		
-		cpusToMineComboBox = new JComboBox<String>();
+                mineUseDirectIO = new JCheckBox(tr("mine_use_direct_io"));
+                mineUseDirectIO.setToolTipText(tr("mine_use_direct_io_details"));
+		mineUseDirectIO.setSelected(!"false".equals(g.getProperty(PROP_MINER_USE_DIRECT_IO)));
+                mineUseDirectIO.addActionListener(this);
+
+                cpusToMineComboBox = new JComboBox<String>();
 		for (int i = 1; i <= coresAvailable; i++) {
 			cpusToMineComboBox.addItem(Integer.toString(i));			
 		}
@@ -400,6 +408,7 @@ public class MiningPanel extends JPanel implements ActionListener, ChangeListene
 		minerPanel2.add(new JLabel(tr("mine_cpus")));
 		minerPanel2.add(cpusToMineComboBox);
 		minerPanel2.add(mineSubmitOnlyBest);
+                minerPanel2.add(mineUseDirectIO);
 		
 		minerPanel1.add(minerAutoStartCheck = new JCheckBox(tr("mine_start_auto")));
 		minerAutoStartCheck.setSelected(Boolean.parseBoolean(g.getProperty(PROP_MINER_AUTO_START)));
@@ -919,6 +928,11 @@ public class MiningPanel extends JPanel implements ActionListener, ChangeListene
 			saveConfs(g);
 			return;
 		}
+                if(mineUseDirectIO == e.getSource()) {
+			g.setProperty(PROP_MINER_USE_DIRECT_IO, Boolean.toString(mineUseDirectIO.isSelected()));
+			saveConfs(g);
+			return;
+		}
 		if(cpusToPlotComboBox == e.getSource()) {
 			g.setProperty(PROP_PLOT_CPU_CORES, Integer.toString(cpusToPlotComboBox.getSelectedIndex()+1));
 			saveConfs(g);
@@ -1386,6 +1400,12 @@ public class MiningPanel extends JPanel implements ActionListener, ChangeListene
 
 			minerConfig.append("additional_headers: \n");
 			minerConfig.append("  \"x-miner\" : \"btdex-" + Globals.getInstance().getVersion() + "\" \n");
+
+                        if(mineUseDirectIO.isSelected()) {
+                            minerConfig.append("hdd_use_direct_io: true               # default true\n");
+                        } else {
+                            minerConfig.append("hdd_use_direct_io: false              # default true\n");
+                        }
 
 			logger.info("Copying miner config to {}", minerConfigFile.getAbsolutePath());
 

--- a/src/main/resources/locale/i18n.btdex.properties
+++ b/src/main/resources/locale/i18n.btdex.properties
@@ -380,3 +380,5 @@ mine_commitment_not_available = Only after PoC+ is activated.
 mine_cpus = CPU Cores
 mine_only_best = Only best deadline
 mine_only_best_details = Submit only the best deadline found per round.
+mine_use_direct_io = Use direct IO
+mine_use_direct_io_details = When enabled, OS caching layer will be bypassed.

--- a/src/main/resources/miner/config.yaml
+++ b/src/main/resources/miner/config.yaml
@@ -1,6 +1,5 @@
 
 hdd_reader_thread_count: 0            # default 0 (=auto: number of disks)
-hdd_use_direct_io: true               # default true
 hdd_wakeup_after: 120                 # default 240s
 
 cpu_nonces_per_cache: 65536           # default 65536


### PR DESCRIPTION
This pull request adds the following checkbox:

- "Use direct IO"

Changes the flag in the miner configuration file; setting is persisted in the BTDEX configuration file as requested.